### PR TITLE
Move context to global, rename accordingly

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,6 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
+import React from 'react';
+import { Store } from './src/state/context';
 
-// You can delete this file if you're not using it
+export const wrapRootElement = ({ element }) => (
+  <Store>{element}</Store>
+)

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,7 +1,6 @@
-/**
- * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/ssr-apis/
- */
+import React from 'react';
+import { Store } from './src/state/context';
 
-// You can delete this file if you're not using it
+export const wrapRootElement = ({ element }) => (
+  <Store>{element}</Store>
+)

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -18,7 +18,7 @@ import {
   SignupStep,
 } from "./steps"
 import ProgressBar from "./progress"
-import { useFormState } from "./context"
+import { useAppState } from "../../state/context"
 import { isEmpty } from "../../utils/object"
 
 const headers = {
@@ -75,7 +75,7 @@ function useFormProgress() {
 }
 
 function PlanForm() {
-  const { state, dispatch } = useFormState()
+  const { state, dispatch } = useAppState()
   const location = useLocation()
   const [currentStep, goForward, goBack] = useFormProgress()
   const [validate, setValidate] = useState(false)

--- a/src/components/form/steps/issues.js
+++ b/src/components/form/steps/issues.js
@@ -2,14 +2,14 @@ import React from "react"
 
 import { Form, Fieldset } from "@trussworks/react-uswds"
 
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 import FormButton from "../buttons"
 
 export function IssuesStep() {
   const {
     state: { issues },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   const allIssues = {
     GUN_VIOLENCE: { t: "Gun Violence", i: "exclamation-triangle" },

--- a/src/components/form/steps/location.js
+++ b/src/components/form/steps/location.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 import React, { useState } from "react"
 
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 import { Form, Fieldset, TextInput } from "@trussworks/react-uswds"
 
 import usePlacesAutocomplete from "use-places-autocomplete"
@@ -16,7 +16,7 @@ let cachedVal = ""
 const acceptedKeys = [38, 40, 13, 27]
 
 export function LocationStep() {
-  const { dispatch } = useFormState()
+  const { dispatch } = useAppState()
 
   const [currIndex, setCurrIndex] = useState(null)
   const {

--- a/src/components/form/steps/money.js
+++ b/src/components/form/steps/money.js
@@ -1,13 +1,13 @@
 import React from "react"
 
 import { Form, Fieldset, RangeInput } from "@trussworks/react-uswds"
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 
 export function MoneyStep() {
   const {
     state: { money },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   return (
     <Form onSubmit={e => e.preventDefault()}>

--- a/src/components/form/steps/reach.js
+++ b/src/components/form/steps/reach.js
@@ -4,7 +4,7 @@ import USAMap from "@jlev/react-usa-map"
 import ReactTooltip from "react-tooltip"
 
 import { Form, Fieldset } from "@trussworks/react-uswds"
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 
 import { updateDict, useReferredState } from "../../../utils/object"
 import { capitalize, isCompetitive, isLikely } from "../../../utils/strings"
@@ -13,7 +13,7 @@ export function ReachStep() {
   const {
     state: { reach },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   const [hoverState, setHoverState] = useReferredState({ current: null })
 

--- a/src/components/form/steps/signup.js
+++ b/src/components/form/steps/signup.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 import {
   Form,
   Fieldset,
@@ -14,7 +14,7 @@ export function SignupStep() {
   const {
     state: { name, contact },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   return (
     <Form onSubmit={e => e.preventDefault()}>

--- a/src/components/form/steps/skills.js
+++ b/src/components/form/steps/skills.js
@@ -2,7 +2,7 @@ import React from "react"
 
 import { Form, Fieldset } from "@trussworks/react-uswds"
 
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 import FormButton from "../buttons"
 
 export const SKILLS_VALUES = {
@@ -21,7 +21,7 @@ export function SkillsStep() {
   const {
     state: { skills },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   const handleChange = skill => {
     const isSelected = skills.includes(skill)

--- a/src/components/form/steps/time.js
+++ b/src/components/form/steps/time.js
@@ -1,7 +1,7 @@
 import React from "react"
 
 import { Form, Fieldset, RangeInput } from "@trussworks/react-uswds"
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 
 export const TIME_VALUES = [
   "help in other ways",
@@ -16,7 +16,7 @@ export function TimeStep() {
   const {
     state: { time },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   return (
     <Form onSubmit={e => e.preventDefault()}>

--- a/src/components/form/steps/vote.js
+++ b/src/components/form/steps/vote.js
@@ -2,14 +2,14 @@ import React from "react"
 
 import { Form, Fieldset } from "@trussworks/react-uswds"
 
-import { useFormState } from "../context"
+import { useAppState } from "../../../state/context"
 import FormButton from "../buttons"
 
 export function VoteStep() {
   const {
     state: { registered, vbm },
     dispatch,
-  } = useFormState()
+  } = useAppState()
 
   return (
     <Form onSubmit={e => e.preventDefault()}>

--- a/src/pages/form.js
+++ b/src/pages/form.js
@@ -3,14 +3,11 @@ import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import PlanForm from "../components/form/form"
-import { FormProvider } from "../components/form/context"
 
 const StartPage = () => (
   <Layout>
     <SEO title="Make a plan" />
-    <FormProvider>
-      <PlanForm />
-    </FormProvider>
+    <PlanForm />
   </Layout>
 )
 

--- a/src/state/context.js
+++ b/src/state/context.js
@@ -1,6 +1,6 @@
 import React, { createContext, useReducer, useContext } from "react"
 
-function formReducer(state, action) {
+function reducer(state, action) {
   switch (action.type) {
     case "SOURCE_CHANGE":
       return { ...state, source: action.payload }
@@ -45,7 +45,7 @@ function formReducer(state, action) {
   }
 }
 
-const FormContext = createContext()
+export const Context = createContext()
 
 const initialState = {
   uid: false,
@@ -72,22 +72,16 @@ const initialState = {
   isSubmissionReceived: false,
 }
 
-export const FormProvider = function ({ children }) {
-  const [state, dispatch] = useReducer(formReducer, initialState)
+export const Store = function ({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState)
 
   return (
-    <FormContext.Provider value={{ state, dispatch }}>
+    <Context.Provider value={{ state, dispatch }}>
       {children}
-    </FormContext.Provider>
+    </Context.Provider>
   )
 }
 
-export function useFormState() {
-  const context = useContext(FormContext)
-
-  if (context === undefined) {
-    throw new Error("useFormState must be used within a FormContext")
-  }
-
-  return context
+export function useAppState() {
+  return useContext(Context)
 }


### PR DESCRIPTION
@jlev this addresses #1. It moves the context store to the top-most level of the application and uses the Gatsby ssr and browser APIs to wrap the entire site. 

Since it moved up to the application level, I renamed it a bit. This fixes the clicking around on the site, but doesn't store the state of the form.