### PR TITLE
fix <Router> component, open up discussion

### DIFF
--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -162,7 +162,7 @@ function PlanForm() {
       <ProgressBar value={currentStep} max={STEPS.length - 1} />
 
       <Router basepath="/form">
-        {stepRender}
+        { STEPS.map(([stepRender]) => stepRender) }
       </Router>
 
       <ButtonGroup className="nav-container">


### PR DESCRIPTION
@jlev this is an incomplete fix, but an example of how to potentially fix the routing. There are two approaches I think you can take to finalize the fixes:

## Solution 1
This PR starts the process of using the Reach `<Router>`. If you use this branch, you'll see that when you navigate a few steps into the form, then click methodology, then click back, the form page renders as expected. There are a few negatives to this as is:

- Refreshing on the page renders the current step and not the first step. This could be solved with some code to redirect users to the appropriate step.
- The progress bar doesn't work if you navigate away from the page since it's linked to [this code](https://github.com/spacedogXYZ/crush2020/blob/master/src/components/form/form.js#L54): `  const [currentStep, setCurrentStep] = useState(0)`. This could be resolved with a little refactoring.

If you write conditional logic to navigate users to other steps appropriately, this solution would be most ideal and work with forward/back buttons. One of those logic statements to accommodate users who refresh might be something like:

```
if (currentStep === 0) {
  navigate('/form');
}
```

## Solution 2

The way you implemented the form with steps rendering dynamically is very similar to a single page app style. If you remove the `<Router>`, remove `navigate` steps, and store the current step in the global context, this page would theoretically work. 

Users would navigate using the buttons (but they would lack the forward and back functionalities). When a user lands on the plan page, it would detect the step they are on from the store and show that content. 

This is an easier solution, but the forward/back buttons might be non-ideal for users. 
